### PR TITLE
upgrade pandas to address dependency problem

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ mysql-connector-python==8.0.16
 mysql-connector==2.2.9
 networkx==2.1
 pandas-gbq==0.10.0
-pandas==0.22.0
+pandas==0.25.1
 psycopg2-binary==2.8.2
 pybase64==0.5.0
 pydata-google-auth==0.1.3


### PR DESCRIPTION
There is an issue with Pandas 0.22 - it depends on a version of Numpy that won't compile against Python 3.7. Upgrading Pandas resolves the issue. Using a different Python version might also suffice but this seems like the most straightforward fix.