### PR TITLE
bump lkml to 0.1.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ google-resumable-media==0.3.1
 googleapis-common-protos==1.5.3
 graphviz==0.10.1
 imageio==2.2.0
-lkml==0.1.1
+lkml==0.1.2
 matplotlib==2.1.2
 mysql-connector-python==8.0.16
 mysql-connector==2.2.9


### PR DESCRIPTION
I didn't test this but I was getting errors about another dependency that required 0.1.2. just as a note, 0.2.2 is also already out